### PR TITLE
Clean up undo history

### DIFF
--- a/plugin/hexmode.vim
+++ b/plugin/hexmode.vim
@@ -83,6 +83,7 @@ if has("autocmd")
 			\ if exists("b:editHex") && b:editHex && &binary |
 			\  let oldro=&ro | let &ro=0 |
 			\  let oldma=&ma | let &ma=1 |
+			\  undojoin |
 			\  silent exe "%!xxd -r" |
 			\  let &ma=oldma | let &ro=oldro |
 			\  unlet oldma | unlet oldro |
@@ -93,6 +94,7 @@ if has("autocmd")
 			\ if exists("b:editHex") && b:editHex && &binary |
 			\  let oldro=&ro | let &ro=0 |
 			\  let oldma=&ma | let &ma=1 |
+			\  undojoin |
 			\  silent exe "%!xxd" |
 			\  exe "set nomod" |
 			\  let &ma=oldma | let &ro=oldro |


### PR DESCRIPTION
Currently, if you change something in your file and save the changes, you need to hit `u` twice to go back to the previous version. Using `undojoin` we can collapse two undo history entries such that they appear as one.
