### PR TITLE
Restore cursor position

### DIFF
--- a/plugin/hexmode.vim
+++ b/plugin/hexmode.vim
@@ -81,6 +81,7 @@ if has("autocmd")
 		" before writing a file when editing in hex mode, convert back to non-hex
 		au BufWritePre *
 			\ if exists("b:editHex") && b:editHex && &binary |
+			\  let oldview = winsaveview() |
 			\  let oldro=&ro | let &ro=0 |
 			\  let oldma=&ma | let &ma=1 |
 			\  silent exe "%!xxd -r" |
@@ -97,6 +98,7 @@ if has("autocmd")
 			\  exe "set nomod" |
 			\  let &ma=oldma | let &ro=oldro |
 			\  unlet oldma | unlet oldro |
+			\  call winrestview(oldview) |
 			\ endif
 	augroup END
 endif


### PR DESCRIPTION
Currently, the cursor position is lost when you save a file. This can be fixed by calling `winsaveview` and `winrestview` before and after invoking `xxd`.
