### PR TITLE
Typo in IsVimFile() causes errors on startup

### DIFF
--- a/plugin/hexmode.vim
+++ b/plugin/hexmode.vim
@@ -52,7 +52,7 @@ function ToggleHex()
 endfunction
 
 " Exclude vim files from auto hexmode
-function isVimFile()
+function IsVimFile()
     let b:path = expand("%:p:h")
 
     " Loop through each directory in the runtime path


### PR DESCRIPTION
The new function `IsVimFile()` is incorrectly spelled with a lower case i, which causes vim to print errors on startup:

```
E128: Function name must start with a capital or "s:": isVimFile()
```

This patch trivially fixes the issue by renaming the function to `IsVimFile()`. It is already referenced by that name in line 87.
