### PR TITLE
Add configurable file patterns; fix undojoin usage

### DIFF
--- a/doc/hexmode.txt
+++ b/doc/hexmode.txt
@@ -45,6 +45,11 @@ mapping).
     inoremap <C-H> <Esc>:Hexmode<CR>
     vnoremap <C-H> :<C-U>Hexmode<CR>
 
+By default, bin and hex files are automatically opened in hex mode.
+Additional file patterns may be added by modifying the
+g:hexmode_patterns variable in your vimrc:
+
+    let g:hexmode_patterns+=*.jpg
 
 =====================================================================
 DEVELOPMENT                                      *HexmodeDevelopment*

--- a/plugin/hexmode.vim
+++ b/plugin/hexmode.vim
@@ -10,6 +10,9 @@ if exists("g:loaded_hexmode_plugin")
 endif
 let g:loaded_hexmode_plugin = 1
 
+" default auto hexmode file patterns
+let g:hexmode_patterns = get(g:, 'hexmode_patterns', '*.bin,*.hex')
+
 " ex command for toggling hex mode - define mapping if desired
 command -bar Hexmode call ToggleHex()
 
@@ -74,7 +77,7 @@ if has("autocmd")
 		au!
 
 		" set binary option for all binary files before reading them
-		au BufReadPre *.bin,*.hex setlocal binary
+		execute printf('au BufReadPre %s setlocal binary', g:hexmode_patterns)
 
 		" if on a fresh read the buffer variable is already set, it's wrong
 		au BufReadPost *
@@ -104,6 +107,7 @@ if has("autocmd")
 			\  silent exe "%!xxd -r" |
 			\  let &ma=oldma | let &ro=oldro |
 			\  unlet oldma | unlet oldro |
+			\  let &undolevels = &undolevels |
 			\ endif
 
 		" after writing a binary file, if we're in hex mode, restore hex mode
@@ -117,6 +121,7 @@ if has("autocmd")
 			\  let &ma=oldma | let &ro=oldro |
 			\  unlet oldma | unlet oldro |
 			\  call winrestview(oldview) |
+			\  let &undolevels = &undolevels |
 			\ endif
 	augroup END
 endif


### PR DESCRIPTION
This PR adds support for configurable file patterns and fixes `undojoin` usage when saving a buffer using the `:write` command. The latter issue is caused by the `BufWritePre` and `BufWritePost` groups being called back-to-back when `:write` is issued. This requires that the undo block be broken before starting another.

From the vim manual:

> To do the opposite, break a change into two undo blocks, in Insert mode use
> CTRL-G u.  This is useful if you want an insert command to be undoable in
> parts.  E.g., for each sentence.  |i_CTRL-G_u|
> Setting the value of 'undolevels' also breaks undo.  Even when the new value
> is equal to the old value.

PS: both changes were quite small, rather than create a pair of smaller PRs, I went ahead and combined these changes. If this is an issue, I'm happy to break these apart!
