### PR TITLE
Use `file` to determine if the file is binary

### DIFF
--- a/plugin/hexmode.vim
+++ b/plugin/hexmode.vim
@@ -87,6 +87,8 @@ if has("autocmd")
         " set binary option for all binary files before reading them
         execute printf('au BufReadPre %s setlocal binary', g:hexmode_patterns)
 
+        let &binary = IsBinary()
+
         " if on a fresh read the buffer variable is already set, it's wrong
         au BufReadPost *
             \ if exists('b:editHex') && b:editHex |
@@ -95,7 +97,7 @@ if has("autocmd")
 
         " convert to hex on startup for binary files automatically
         au BufReadPost *
-            \ if IsBinary() && !IsVimFile() | Hexmode | endif
+            \ if &binary && !IsVimFile() | Hexmode | endif
 
         " When the text is freed, the next time the buffer is made active it will
         " re-read the text and thus not match the correct mode, we will need to
@@ -107,7 +109,7 @@ if has("autocmd")
 
         " before writing a file when editing in hex mode, convert back to non-hex
         au BufWritePre *
-            \ if exists("b:editHex") && b:editHex && IsBinary() |
+            \ if exists("b:editHex") && b:editHex && &binary |
             \  let oldview = winsaveview() |
             \  let oldro=&ro | let &ro=0 |
             \  let oldma=&ma | let &ma=1 |
@@ -120,7 +122,7 @@ if has("autocmd")
 
         " after writing a binary file, if we're in hex mode, restore hex mode
         au BufWritePost *
-            \ if exists("b:editHex") && b:editHex && IsBinary() |
+            \ if exists("b:editHex") && b:editHex && &binary |
             \  let oldro=&ro | let &ro=0 |
             \  let oldma=&ma | let &ma=1 |
             \  undojoin |

--- a/plugin/hexmode.vim
+++ b/plugin/hexmode.vim
@@ -70,13 +70,21 @@ function IsVimFile()
     return 0
 endfunction
 
+function! IsBinary()
+    if executable('file')
+        return system('file -ib ' . shellescape(expand('%:p'))) =~# 'charset=binary'
+    else
+        return &binary
+    endif
+endfunction
+
 " autocmds to automatically enter hex mode and handle file writes properly
 if has("autocmd")
 	" vim -b : edit binary using xxd-format!
 	augroup Binary
 		au!
 
-		" set binary option for all binary files before reading them
+        " set binary option for all binary files before reading them
 		execute printf('au BufReadPre %s setlocal binary', g:hexmode_patterns)
 
 		" if on a fresh read the buffer variable is already set, it's wrong
@@ -87,7 +95,7 @@ if has("autocmd")
 
 		" convert to hex on startup for binary files automatically
 		au BufReadPost *
-			\ if &binary && !IsVimFile() | Hexmode | endif
+			\ if IsBinary() && !IsVimFile() | Hexmode | endif
 
 		" When the text is freed, the next time the buffer is made active it will
 		" re-read the text and thus not match the correct mode, we will need to
@@ -99,7 +107,7 @@ if has("autocmd")
 
 		" before writing a file when editing in hex mode, convert back to non-hex
 		au BufWritePre *
-			\ if exists("b:editHex") && b:editHex && &binary |
+			\ if exists("b:editHex") && b:editHex && IsBinary() |
 			\  let oldview = winsaveview() |
 			\  let oldro=&ro | let &ro=0 |
 			\  let oldma=&ma | let &ma=1 |
@@ -112,7 +120,7 @@ if has("autocmd")
 
 		" after writing a binary file, if we're in hex mode, restore hex mode
 		au BufWritePost *
-			\ if exists("b:editHex") && b:editHex && &binary |
+			\ if exists("b:editHex") && b:editHex && IsBinary() |
 			\  let oldro=&ro | let &ro=0 |
 			\  let oldma=&ma | let &ma=1 |
 			\  undojoin |

--- a/plugin/hexmode.vim
+++ b/plugin/hexmode.vim
@@ -18,40 +18,40 @@ command -bar Hexmode call ToggleHex()
 
 " helper function to toggle hex mode
 function ToggleHex()
-	" hex mode should be considered a read-only operation
-	" save values for modified and read-only for restoration later,
-	" and clear the read-only flag for now
-	let l:modified=&mod
-	let l:oldreadonly=&readonly
-	let &readonly=0
-	let l:oldmodifiable=&modifiable
-	let &modifiable=1
-	if !exists("b:editHex") || !b:editHex
-	" save old options
-	let b:oldft=&ft
-	let b:oldbin=&bin
-	" set new options
-	setlocal binary " make sure it overrides any textwidth, etc.
-	let &ft="xxd"
-	" set status
-	let b:editHex=1
-	" switch to hex editor
-	silent %!xxd
-	else
-	" restore old options
-	let &ft=b:oldft
-	if !b:oldbin
-	setlocal nobinary
-	endif
-	" set status
-	let b:editHex=0
-	" return to normal editing
-	silent %!xxd -r
-	endif
-	" restore values for modified and read only state
-	let &mod=l:modified
-	let &readonly=l:oldreadonly
-	let &modifiable=l:oldmodifiable
+    " hex mode should be considered a read-only operation
+    " save values for modified and read-only for restoration later,
+    " and clear the read-only flag for now
+    let l:modified=&mod
+    let l:oldreadonly=&readonly
+    let &readonly=0
+    let l:oldmodifiable=&modifiable
+    let &modifiable=1
+    if !exists("b:editHex") || !b:editHex
+    " save old options
+    let b:oldft=&ft
+    let b:oldbin=&bin
+    " set new options
+    setlocal binary " make sure it overrides any textwidth, etc.
+    let &ft="xxd"
+    " set status
+    let b:editHex=1
+    " switch to hex editor
+    silent %!xxd
+    else
+    " restore old options
+    let &ft=b:oldft
+    if !b:oldbin
+    setlocal nobinary
+    endif
+    " set status
+    let b:editHex=0
+    " return to normal editing
+    silent %!xxd -r
+    endif
+    " restore values for modified and read only state
+    let &mod=l:modified
+    let &readonly=l:oldreadonly
+    let &modifiable=l:oldmodifiable
 endfunction
 
 " Exclude vim files from auto hexmode
@@ -80,58 +80,58 @@ endfunction
 
 " autocmds to automatically enter hex mode and handle file writes properly
 if has("autocmd")
-	" vim -b : edit binary using xxd-format!
-	augroup Binary
-		au!
+    " vim -b : edit binary using xxd-format!
+    augroup Binary
+        au!
 
         " set binary option for all binary files before reading them
-		execute printf('au BufReadPre %s setlocal binary', g:hexmode_patterns)
+        execute printf('au BufReadPre %s setlocal binary', g:hexmode_patterns)
 
-		" if on a fresh read the buffer variable is already set, it's wrong
-		au BufReadPost *
-			\ if exists('b:editHex') && b:editHex |
-			\   let b:editHex = 0 |
-			\ endif
+        " if on a fresh read the buffer variable is already set, it's wrong
+        au BufReadPost *
+            \ if exists('b:editHex') && b:editHex |
+            \   let b:editHex = 0 |
+            \ endif
 
-		" convert to hex on startup for binary files automatically
-		au BufReadPost *
-			\ if IsBinary() && !IsVimFile() | Hexmode | endif
+        " convert to hex on startup for binary files automatically
+        au BufReadPost *
+            \ if IsBinary() && !IsVimFile() | Hexmode | endif
 
-		" When the text is freed, the next time the buffer is made active it will
-		" re-read the text and thus not match the correct mode, we will need to
-		" convert it again if the buffer is again loaded.
-		au BufUnload *
-			\ if getbufvar(expand("<afile>"), 'editHex') == 1 |
-			\   call setbufvar(expand("<afile>"), 'editHex', 0) |
-			\ endif
+        " When the text is freed, the next time the buffer is made active it will
+        " re-read the text and thus not match the correct mode, we will need to
+        " convert it again if the buffer is again loaded.
+        au BufUnload *
+            \ if getbufvar(expand("<afile>"), 'editHex') == 1 |
+            \   call setbufvar(expand("<afile>"), 'editHex', 0) |
+            \ endif
 
-		" before writing a file when editing in hex mode, convert back to non-hex
-		au BufWritePre *
-			\ if exists("b:editHex") && b:editHex && IsBinary() |
-			\  let oldview = winsaveview() |
-			\  let oldro=&ro | let &ro=0 |
-			\  let oldma=&ma | let &ma=1 |
-			\  undojoin |
-			\  silent exe "%!xxd -r" |
-			\  let &ma=oldma | let &ro=oldro |
-			\  unlet oldma | unlet oldro |
-			\  let &undolevels = &undolevels |
-			\ endif
+        " before writing a file when editing in hex mode, convert back to non-hex
+        au BufWritePre *
+            \ if exists("b:editHex") && b:editHex && IsBinary() |
+            \  let oldview = winsaveview() |
+            \  let oldro=&ro | let &ro=0 |
+            \  let oldma=&ma | let &ma=1 |
+            \  undojoin |
+            \  silent exe "%!xxd -r" |
+            \  let &ma=oldma | let &ro=oldro |
+            \  unlet oldma | unlet oldro |
+            \  let &undolevels = &undolevels |
+            \ endif
 
-		" after writing a binary file, if we're in hex mode, restore hex mode
-		au BufWritePost *
-			\ if exists("b:editHex") && b:editHex && IsBinary() |
-			\  let oldro=&ro | let &ro=0 |
-			\  let oldma=&ma | let &ma=1 |
-			\  undojoin |
-			\  silent exe "%!xxd" |
-			\  exe "set nomod" |
-			\  let &ma=oldma | let &ro=oldro |
-			\  unlet oldma | unlet oldro |
-			\  call winrestview(oldview) |
-			\  let &undolevels = &undolevels |
-			\ endif
-	augroup END
+        " after writing a binary file, if we're in hex mode, restore hex mode
+        au BufWritePost *
+            \ if exists("b:editHex") && b:editHex && IsBinary() |
+            \  let oldro=&ro | let &ro=0 |
+            \  let oldma=&ma | let &ma=1 |
+            \  undojoin |
+            \  silent exe "%!xxd" |
+            \  exe "set nomod" |
+            \  let &ma=oldma | let &ro=oldro |
+            \  unlet oldma | unlet oldro |
+            \  call winrestview(oldview) |
+            \  let &undolevels = &undolevels |
+            \ endif
+    augroup END
 endif
 
 " vim: set et sts=4 sw=4:

--- a/plugin/hexmode.vim
+++ b/plugin/hexmode.vim
@@ -72,7 +72,7 @@ endfunction
 
 function! IsBinary()
     if executable('file')
-        return system('file -ib ' . shellescape(expand('%:p'))) =~# 'charset=binary'
+        return system('file -ibL ' . shellescape(expand('%:p'))) =~# 'charset=binary'
     else
         return &binary
     endif


### PR DESCRIPTION
`file` utility uses magic numbers to better determine if the file is binary, even if it doesn't have any extension.

The `file` utility is present in most distros by default, but if it isn't, the plugin falls back into old behavior (using file extension).

Also mixed tabs and spaces replaced with spaces only.
