### PR TITLE
Reduce false positive binaries from file command.

### DIFF
--- a/plugin/hexmode.vim
+++ b/plugin/hexmode.vim
@@ -71,14 +71,15 @@ function IsVimFile()
 endfunction
 
 function! IsBinary()
-    if executable('file')
+    if &binary
+        return 1
+    elseif executable('file')
         let file = system('file -ibL ' . shellescape(expand('%:p')))
         return file !~# 'inode/x-empty'
             \ && file !~# 'inode/fifo'
             \ && file =~# 'charset=binary'
-    else
-        return &binary
     endif
+    return 0
 endfunction
 
 " autocmds to automatically enter hex mode and handle file writes properly

--- a/plugin/hexmode.vim
+++ b/plugin/hexmode.vim
@@ -72,7 +72,10 @@ endfunction
 
 function! IsBinary()
     if executable('file')
-        return system('file -ibL ' . shellescape(expand('%:p'))) =~# 'charset=binary'
+        let file = system('file -ibL ' . shellescape(expand('%:p')))
+        return file !~# 'inode/x-empty'
+            \ && file !~# 'inode/fifo'
+            \ && file =~# 'charset=binary'
     else
         return &binary
     endif


### PR DESCRIPTION
Very annoying when trying to edit an empty file or diffing some
program output (e.g., `vimdiff <(command 1) <(command 2)`).

```
$ file -ibL <empty file>
inode/x-empty; charset=binary
$ file -ibL <(<some command>)
inode/fifo; charset=binary
```
