### PR TITLE
Ignore undojoin error when saving after undo

### DIFF
--- a/plugin/hexmode.vim
+++ b/plugin/hexmode.vim
@@ -121,7 +121,7 @@ if has("autocmd")
             \  let b:oldview = winsaveview() |
             \  let b:oldro=&l:ro | let &l:ro=0 |
             \  let b:oldma=&l:ma | let &l:ma=1 |
-            \  undojoin |
+            \  try | undojoin | catch /^Vim\%((\a\+)\)\=:E790/ | endtry |
             \  silent exe "%!xxd -r " . g:hexmode_xxd_options |
             \  let &l:ma=b:oldma | let &l:ro=b:oldro |
             \  unlet b:oldma | unlet b:oldro |
@@ -133,7 +133,7 @@ if has("autocmd")
             \ if exists("b:editHex") && b:editHex |
             \  let b:oldro=&l:ro | let &l:ro=0 |
             \  let b:oldma=&l:ma | let &l:ma=1 |
-            \  undojoin |
+            \  try | undojoin | catch /^Vim\%((\a\+)\)\=:E790/ | endtry |
             \  silent exe "%!xxd " . g:hexmode_xxd_options |
             \  exe "setlocal nomod" |
             \  let &l:ma=b:oldma | let &l:ro=b:oldro |


### PR DESCRIPTION
The changeset in https://github.com/fidian/hexmode/pull/1 allows a user
to only press `u` once to revert to the previous version of the file
after saving. However, if the user presses `u` and then saves, an error
is thrown, since undojoin cannot be called after an undo.

To workaround this issue, we catch and silently ignore this error. This
allows saving after an undo, but two presses of `u` are required to
revert to the previous state.